### PR TITLE
Initial implementation of event tracking

### DIFF
--- a/completion/apps.py
+++ b/completion/apps.py
@@ -26,6 +26,9 @@ class CompletionAppConfig(AppConfig):
                 'common': {
                     'relative_path': 'settings.common',
                 },
+                'aws': {
+                    'relative_path': 'settings.aws',
+                },
             },
         },
         'signals_config': {

--- a/completion/models.py
+++ b/completion/models.py
@@ -14,6 +14,7 @@ from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 from opaque_keys.edx.keys import CourseKey
 
+from . import tracking
 from . import waffle
 
 # pylint: disable=ungrouped-imports
@@ -96,6 +97,7 @@ class BlockCompletionManager(models.Manager):
                 block_key=block_key,
                 defaults={'completion': completion},
             )
+            tracking.track_completion_event(obj, completion, is_new)
             if not is_new and obj.completion != completion:
                 obj.completion = completion
                 obj.full_clean()

--- a/completion/settings/aws.py
+++ b/completion/settings/aws.py
@@ -1,0 +1,18 @@
+"""
+Production plugin settings i.e., aws, for completion.
+"""
+
+
+def plugin_settings(settings):
+    """
+    Modify the provided settings object with settings specific to this plugin.
+    """
+    settings.COMPLETION_ENABLE_EVENTTRACKING = settings.ENV_TOKENS.get(
+        'COMPLETION_ENABLE_EVENTTRACKING',
+        settings.COMPLETION_ENABLE_EVENTTRACKING,
+    )
+
+    settings.COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST = set(settings.ENV_TOKENS.get(
+        'COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST',
+        settings.COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST,
+    ))

--- a/completion/settings/common.py
+++ b/completion/settings/common.py
@@ -41,3 +41,7 @@ def plugin_settings(settings):  # pylint: disable=unused-argument
     # Once a user has watched this percentage of a video, mark it as complete:
     # (0.0 = 0%, 1.0 = 100%)
     settings.COMPLETION_VIDEO_COMPLETE_PERCENTAGE = 0.95
+
+    # Settings for tracking
+    settings.COMPLETION_ENABLE_EVENTTRACKING = False
+    settings.COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST = []

--- a/completion/tracking.py
+++ b/completion/tracking.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+"""
+Tracking and analytics events for block completions.
+"""
+
+from django.conf import settings
+
+from eventtracking import tracker
+
+from openedx.core.djangoapps.site_configuration import helpers
+
+
+TRACKER_EVENT_NAME_FORMAT = u'edx.completion.{block_type}.{event_type}'
+
+
+def _is_trackable_block_type(block_type):
+    """
+    Checks settings to see if we want to track this block type.
+    We use a black list and assume tracking of all, otherwise.
+    """
+    return block_type not in helpers.get_value(
+        'COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST',
+        settings.COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST)
+
+
+def track_completion_event(blockcompletion, completion_percent, is_new):
+    """
+    Logic for emitting or skipping a tracking event for a completed block.
+
+    """
+    if helpers.get_value(
+        'COMPLETION_ENABLE_EVENTTRACKING', settings.COMPLETION_ENABLE_EVENTTRACKING) is not True:
+        return
+
+    if not _is_trackable_block_type(blockcompletion.block_type):
+        return
+
+    if is_new:
+        if completion_percent == 1.0:
+            event_type = 'completed'
+        else:
+            return
+    elif not is_new:
+        if completion_percent == 1.0:
+            event_type = 'completed'
+        # this code executes before new completion percentage saved to BlockCompletion
+        elif blockcompletion.completion == 1.0 and completion_percent < 1:
+            event_type = 'uncompleted'
+        else:
+            return
+
+    event_name = TRACKER_EVENT_NAME_FORMAT.format(
+        block_type=blockcompletion.block_type, 
+        event_type=event_type
+    )
+
+    block_id = str(blockcompletion.block_key)
+    course_id = str(blockcompletion.course_key)
+
+    tracker.emit(event_name, {
+        'label': '{} {} {}'.format(blockcompletion.block_type, block_id, event_type),
+        'course_id': str(blockcompletion.course_key),
+        'block_id': block_id,
+        'block_type': blockcompletion.block_type,
+    })


### PR DESCRIPTION
**This is lower priority now than the [similar completion_aggregator PR ](https://github.com/appsembler/openedx-completion-aggregator/pull/1) and related [event-tracking PR](https://github.com/appsembler/completion/pull/1)**

Emit completion and uncompletion events using eventtracking's Tracker.

Emit `edx.completion.{block_type}.completed` (block type is like 'problem', 'htm', 'drag-and-drop-v2', etc.) when a `BlockCompletion` is *created* or *updated* (using the `BlockCompletionManager's` `submit_completion()` method only)  and the percent complete is changes to 100 — i.e., emit only once per completion.

Emit `edx.completion.{block_type}.uncompleted` when a `BlockCompletion` is *updated* (again through the `submit_completion()` method and the completion percent moves from 100% to something less. 

These are generic events that can be sent to any backend but specifically are not prepared for BI.

It's configurable with defaults set and overridable via `SiteConfiguration`

`COMPLETION_ENABLE_EVENTTRACKING` to enable. Defaults to False.  
Reviewer:  Should we use a Waffle swtich instead?  That's a little weirder to deal with for Site-specific config.

`COMPLETION_TRACKED_BLOCK_TYPE_BLACKLIST` to not track certain block types.  Defaults to empty.  Used a blacklist instead of a whitelist since we don't know in advance what all the block types there will be that are completable.






